### PR TITLE
Semihosting requires cooperation with the execution environment

### DIFF
--- a/riscv-semihosting-spec.adoc
+++ b/riscv-semihosting-spec.adoc
@@ -98,3 +98,10 @@ the fields in the data block, which depend on whether the caller is
 | RETURN REGISTER                   |  A0    |   A0  
 | Data block field size             | 32 bits| 64 bits
 |===
+
+=== Semihosting Execution Environment
+
+Any configuration required to support semihosting on RISC-V systems must be
+defined by the execution environment.  Of particular interest is the RISC-V
+external debug specification, which allows M-mode (and optionally S/U modes)
+`ebreak` instructions to be treated as semihosting traps.


### PR DESCRIPTION
Semihosting doesn't work in a vacuum, it needs something to implement
this ABI from outside the execution environment in question.  This
specifically came up as a "why don't ebreaks from U-mode result in
semihosting traps in QEMU?" discussion, I couldn't find anything to
point to saying that's the expected behavior.

I'm not sure this would really help anyone who's confused about this,
but at least it's something to point to next time.