### PR TITLE
Relax an overly-strict requirement for systems with paging

### DIFF
--- a/riscv-semihosting-spec.adoc
+++ b/riscv-semihosting-spec.adoc
@@ -60,7 +60,7 @@ srai x0, x0, 7          # 0x40705013    NOP encoding the semihosting call number
 
 These three instructions must be 32-bit-wide instructions, they may
 not be compressed 16-bit instructions. This same sequence is used on
-all RISC-V architectures. On systems with paging support, this
+all RISC-V architectures. If paging is in use in the current mode, this
 sequence must not cross a page boundary as the semihosting system must
 be able to check for the semihosting sequence without needing data
 from potentially missing pages. <<function>> shows how this can be done


### PR DESCRIPTION
Just because a system has paging does not mean it is currently in use.
Running a simple RTOS on a full Sv39-supporting core that doesn't enable
it is no different to running on one without Sv39 support, and crossing
a page boundary is totally fine. Similarly, firmware running in M-mode
on a Unix-capable core with a full OS running in S-mode with paging can
still not care about paging, since the firmware's own program counter is
not subject to translation.
